### PR TITLE
fix: destruct the returned value of getVirtualFileByUri to file

### DIFF
--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -19,7 +19,7 @@ const plugin: LanguageServerPlugin = () => ({
 				validation: {
 					onSyntactic(document) {
 
-						const file = context.documents.getVirtualFileByUri(document.uri);
+						const [file] = context.documents.getVirtualFileByUri(document.uri);
 						if (!(file instanceof Html1File)) return;
 
 						const styleNodes = file.htmlDocument.roots.filter(root => root.tag === 'style');


### PR DESCRIPTION
The return value of `getVirtualFileByUri` is a tuple of type `readonly [VirtualFile, import("@volar/language-core").Source] | readonly [undefined, undefined]`, and hence should be destructed to get its first component, virtual file.

After fixing this, the sample code to demonstrate diagnostics ("only one style tag is allowed") works.